### PR TITLE
Adding pdo_sqlite to required modules in dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
         "symfony/process": "~2.3",
         "symfony/translation": "~2.3",
         "symfony/twig-bridge": "~2.3",
-        "twig/twig": "~1.8"
+        "twig/twig": "~1.8",
+        "ext-pdo_sqlite": "*"
     },
     "type": "library"
 }


### PR DESCRIPTION
Might be stupid but when I tested the app, I didn't think about in my clean environment, which drove me to weird bugs. Apparently, Travis has it by default, but you never know :)
