### PR TITLE
Load users in Symfony resource provider

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/ResourceProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/ResourceProvider.php
@@ -83,6 +83,9 @@ class ResourceProvider implements AuthenticationProviderInterface
                 // No user with this username, but there is a valid access token, so thats all good
             }
         }
+        $roles = array_merge($roles, array_map(function($scope) {
+            return 'ROLE_SCOPE_' . strtoupper($scope);
+        }, $scope));
 
         $tokenAuthenticated = new AccessToken(
             $this->providerKey,

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AccessToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AccessToken.php
@@ -36,7 +36,8 @@ class AccessToken extends AbstractToken implements AccessTokenInterface
         $username = '',
         $expires = '',
         array $scope = [],
-        array $roles = []
+        array $roles = [],
+        $user = null
     ) {
         parent::__construct($roles);
 
@@ -48,6 +49,9 @@ class AccessToken extends AbstractToken implements AccessTokenInterface
         $this->username = $username;
         $this->expires = $expires;
         $this->scope = $scope;
+        if (null !== $user) {
+            $this->setUser($user);
+        }
 
         parent::setAuthenticated(count($roles) > 0);
     }


### PR DESCRIPTION
Allows the token to contain not just the username but the actual user
object, using a user provider
Also the token will have roles from the user