### PR TITLE
Use random_bytes from php7 for a reliable and secure random number generator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "symfony/http-foundation": "~3.2",
         "symfony/http-kernel": "~3.2",
         "symfony/security": "~3.2",
-        "symfony/validator": "~3.2"
+        "symfony/validator": "~3.2",
+        "paragonie/random_compat": "^2.0"
     },
     "require-dev": {
         "doctrine/data-fixtures": "~1.0",

--- a/src/ResponseType/CodeResponseTypeHandler.php
+++ b/src/ResponseType/CodeResponseTypeHandler.php
@@ -48,7 +48,7 @@ class CodeResponseTypeHandler extends AbstractResponseTypeHandler
         $codeManager = $this->modelManagerFactory->getModelManager('code');
         $class = $codeManager->getClassName();
         $code = new $class();
-        $code->setCode(md5(openssl_random_pseudo_bytes(256)))
+        $code->setCode(bin2hex(random_bytes(64)))
             ->setClientId($clientId)
             ->setUsername($username)
             ->setRedirectUri($redirectUri)

--- a/src/TokenType/BearerTokenTypeHandler.php
+++ b/src/TokenType/BearerTokenTypeHandler.php
@@ -75,7 +75,7 @@ class BearerTokenTypeHandler extends AbstractTokenTypeHandler
         $accessTokenManager = $this->modelManagerFactory->getModelManager('access_token');
         $class = $accessTokenManager->getClassName();
         $accessToken = new $class();
-        $accessToken->setAccessToken(md5(openssl_random_pseudo_bytes(256)))
+        $accessToken->setAccessToken(bin2hex(random_bytes(64)))
             ->setTokenType('bearer')
             ->setClientId($clientId)
             ->setUsername($username)
@@ -101,7 +101,7 @@ class BearerTokenTypeHandler extends AbstractTokenTypeHandler
             $refreshTokenManager = $this->modelManagerFactory->getModelManager('refresh_token');
             $class = $refreshTokenManager->getClassName();
             $refreshToken = new $class();
-            $refreshToken->setRefreshToken(md5(openssl_random_pseudo_bytes(256)))
+            $refreshToken->setRefreshToken(bin2hex(random_bytes(64)))
                 ->setClientId($clientId)
                 ->setUsername($username)
                 ->setExpires(new \DateTime('+1 days'))


### PR DESCRIPTION
- Included backwards compatibility
- Dont ruin the good random with md5
- Uses 127 bytes so that it fits in a doctrine default string length (the hex string is 254 chars)