### PR TITLE
Allow all types of token that contain a username for authorization endpoint

### DIFF
--- a/src/ResponseType/AbstractResponseTypeHandler.php
+++ b/src/ResponseType/AbstractResponseTypeHandler.php
@@ -57,7 +57,7 @@ abstract class AbstractResponseTypeHandler implements ResponseTypeHandlerInterfa
     protected function checkUsername()
     {
         $token = $this->tokenStorage->getToken();
-        if (!$token instanceof RememberMeToken && !$token instanceof UsernamePasswordToken) {
+        if (!$token->getUsername()) {
             throw new ServerErrorException([
                 'error_description' => 'The authorization server encountered an unexpected condition that prevented it from fulfilling the request.',
             ]);


### PR DESCRIPTION
No reason to limit this to form login tokens