### PR TITLE
Dont throw exception when credentials are missing

### DIFF
--- a/src/Silex/Provider/AuthBucketOAuth2ServiceProvider.php
+++ b/src/Silex/Provider/AuthBucketOAuth2ServiceProvider.php
@@ -20,6 +20,8 @@ use AuthBucket\OAuth2\ResponseType\ResponseTypeHandlerFactory;
 use AuthBucket\OAuth2\Symfony\Component\EventDispatcher\ExceptionListener;
 use AuthBucket\OAuth2\Symfony\Component\Security\Core\Authentication\Provider\ResourceProvider;
 use AuthBucket\OAuth2\Symfony\Component\Security\Core\Authentication\Provider\TokenProvider;
+use AuthBucket\OAuth2\Symfony\Component\Security\Http\EntryPoint\ResourceAuthenticationEntryPoint;
+use AuthBucket\OAuth2\Symfony\Component\Security\Http\EntryPoint\TokenAuthenticationEntryPoint;
 use AuthBucket\OAuth2\Symfony\Component\Security\Http\Firewall\ResourceListener;
 use AuthBucket\OAuth2\Symfony\Component\Security\Http\Firewall\TokenListener;
 use AuthBucket\OAuth2\TokenType\TokenTypeHandlerFactory;
@@ -149,6 +151,14 @@ class AuthBucketOAuth2ServiceProvider implements ServiceProviderInterface, Event
             );
         };
 
+        $app['authbucket_oauth2.token_entry_point'] = function () {
+            return new TokenAuthenticationEntryPoint();
+        };
+
+        $app['authbucket_oauth2.resource_entry_point'] = function () {
+            return new ResourceAuthenticationEntryPoint();
+        };
+
         $app['security.authentication_provider.oauth2_token._proto'] = $app->protect(function ($name, $options) use ($app) {
             return function () use ($app, $name, $options) {
                 return new TokenProvider(
@@ -207,7 +217,7 @@ class AuthBucketOAuth2ServiceProvider implements ServiceProviderInterface, Event
             return [
                 'security.authentication_provider.'.$name.'.oauth2_token',
                 'security.authentication_listener.'.$name.'.oauth2_token',
-                null,
+                'authbucket_oauth2.token_entry_point',
                 'pre_auth',
             ];
         });
@@ -230,7 +240,7 @@ class AuthBucketOAuth2ServiceProvider implements ServiceProviderInterface, Event
             return [
                 'security.authentication_provider.'.$name.'.oauth2_resource',
                 'security.authentication_listener.'.$name.'.oauth2_resource',
-                null,
+                'authbucket_oauth2.resource_entry_point',
                 'pre_auth',
             ];
         });

--- a/src/Symfony/Component/Security/Http/EntryPoint/ResourceAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/ResourceAuthenticationEntryPoint.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace AuthBucket\OAuth2\Symfony\Component\Security\Http\EntryPoint;
+
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+
+class ResourceAuthenticationEntryPoint implements AuthenticationEntryPointInterface
+{
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        return new JsonResponse(['error'=>'invalid_request', 'error_message' => 'Authentication token required'], 401);
+    }
+}

--- a/src/Symfony/Component/Security/Http/EntryPoint/TokenAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/TokenAuthenticationEntryPoint.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace AuthBucket\OAuth2\Symfony\Component\Security\Http\EntryPoint;
+
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+
+class TokenAuthenticationEntryPoint implements AuthenticationEntryPointInterface
+{
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        return new JsonResponse(['error'=>'invalid_request', 'error_message' => 'Client id and secret required'], 401);
+    }
+}

--- a/src/Symfony/Component/Security/Http/Firewall/ResourceListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ResourceListener.php
@@ -68,10 +68,9 @@ class ResourceListener implements ListenerInterface
                 continue;
             }
         }
+        // If there is no access token then dont continue
         if ($accessToken === null) {
-            throw new InvalidRequestException([
-                'error_description' => 'The request includes an invalid parameter value.',
-            ]);
+            return;
         }
 
         // access_token must in valid format.

--- a/src/Symfony/Component/Security/Http/Firewall/TokenListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/TokenListener.php
@@ -72,6 +72,11 @@ class TokenListener implements ListenerInterface
             $clientSecret = $request->request->get('client_secret', false);
         }
 
+        // If there is no client then dont continue
+        if ($clientId === false && $clientSecret === false) {
+            return;
+        }
+
         // client_id must in valid format.
         $errors = $this->validator->validate($clientId, [
             new \Symfony\Component\Validator\Constraints\NotBlank(),

--- a/tests/Controller/OAuth2ControllerTest.php
+++ b/tests/Controller/OAuth2ControllerTest.php
@@ -152,6 +152,7 @@ class OAuth2ControllerTest extends WebTestCase
         ];
         $client = $this->createClient();
         $crawler = $client->request('GET', '/api/oauth2/debug', $parameters, [], $server);
+        $this->assertEquals(401, $client->getResponse()->getStatusCode());
         $resourceResponse = json_decode($client->getResponse()->getContent(), true);
         $this->assertSame('invalid_request', $resourceResponse['error']);
     }

--- a/tests/TokenType/BearerTokenTypeHandlerTest.php
+++ b/tests/TokenType/BearerTokenTypeHandlerTest.php
@@ -22,7 +22,7 @@ class BearerTokenTypeHandlerTest extends WebTestCase
         $server = [];
         $client = $this->createClient();
         $crawler = $client->request('GET', '/api/oauth2/debug', $parameters, [], $server);
-        $this->assertSame(400, $client->getResponse()->getStatusCode());
+        $this->assertSame(401, $client->getResponse()->getStatusCode());
         $this->assertNotNull(json_decode($client->getResponse()->getContent()));
         $tokenResponse = json_decode($client->getResponse()->getContent(), true);
         $this->assertSame('invalid_request', $tokenResponse['error']);
@@ -38,7 +38,7 @@ class BearerTokenTypeHandlerTest extends WebTestCase
         ];
         $client = $this->createClient();
         $crawler = $client->request('GET', '/api/oauth2/debug', $parameters, [], $server);
-        $this->assertSame(400, $client->getResponse()->getStatusCode());
+        $this->assertSame(401, $client->getResponse()->getStatusCode());
         $this->assertNotNull(json_decode($client->getResponse()->getContent()));
         $tokenResponse = json_decode($client->getResponse()->getContent(), true);
         $this->assertSame('invalid_request', $tokenResponse['error']);


### PR DESCRIPTION
This allows to combine the listeners with other firewalls
For example an api might have resource listener and a basic auth listener