### PR TITLE
Authorize based on grant type

### DIFF
--- a/src/GrantType/AuthorizationCodeGrantTypeHandler.php
+++ b/src/GrantType/AuthorizationCodeGrantTypeHandler.php
@@ -23,6 +23,8 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class AuthorizationCodeGrantTypeHandler extends AbstractGrantTypeHandler
 {
+    const GRANT_TYPE = 'authorization_code';
+
     public function handle(Request $request)
     {
         // Fetch client_id from authenticated token.

--- a/src/GrantType/ClientCredentialsGrantTypeHandler.php
+++ b/src/GrantType/ClientCredentialsGrantTypeHandler.php
@@ -21,6 +21,8 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class ClientCredentialsGrantTypeHandler extends AbstractGrantTypeHandler
 {
+    const GRANT_TYPE = 'client_credentials';
+
     public function handle(Request $request)
     {
         // Fetch client_id from authenticated token.

--- a/src/GrantType/PasswordGrantTypeHandler.php
+++ b/src/GrantType/PasswordGrantTypeHandler.php
@@ -30,6 +30,8 @@ use Symfony\Component\Security\Core\User\UserChecker;
  */
 class PasswordGrantTypeHandler extends AbstractGrantTypeHandler
 {
+    const GRANT_TYPE = 'password';
+
     public function handle(Request $request)
     {
         // Fetch client_id from authenticated token.

--- a/src/GrantType/RefreshTokenGrantTypeHandler.php
+++ b/src/GrantType/RefreshTokenGrantTypeHandler.php
@@ -24,6 +24,8 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class RefreshTokenGrantTypeHandler extends AbstractGrantTypeHandler
 {
+    const GRANT_TYPE = 'refresh_token';
+
     public function handle(Request $request)
     {
         // Fetch client_id from authenticated token.

--- a/src/Model/AuthorizeInterface.php
+++ b/src/Model/AuthorizeInterface.php
@@ -65,4 +65,11 @@ interface AuthorizeInterface extends ModelInterface
      * @return array
      */
     public function getScope();
+
+    /**
+     * Get Grant types that this client is allowed to use.
+     *
+     * @return array
+     */
+    public function getGrantType();
 }

--- a/src/ResponseType/CodeResponseTypeHandler.php
+++ b/src/ResponseType/CodeResponseTypeHandler.php
@@ -11,6 +11,7 @@
 
 namespace AuthBucket\OAuth2\ResponseType;
 
+use AuthBucket\OAuth2\GrantType\AuthorizationCodeGrantTypeHandler;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -21,6 +22,8 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class CodeResponseTypeHandler extends AbstractResponseTypeHandler
 {
+    const GRANT_TYPE = AuthorizationCodeGrantTypeHandler::GRANT_TYPE;
+
     public function handle(Request $request)
     {
         // Fetch username from authenticated token.

--- a/src/ResponseType/TokenResponseTypeHandler.php
+++ b/src/ResponseType/TokenResponseTypeHandler.php
@@ -22,6 +22,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class TokenResponseTypeHandler extends AbstractResponseTypeHandler
 {
+    const GRANT_TYPE = 'implicit';
+
     public function handle(Request $request)
     {
         // Fetch username from authenticated token.

--- a/tests/TestBundle/DataFixtures/ORM/AuthorizeFixture.php
+++ b/tests/TestBundle/DataFixtures/ORM/AuthorizeFixture.php
@@ -77,6 +77,11 @@ class AuthorizeFixture implements FixtureInterface
             ->setUsername('demousername1')
             ->setScope([
                 'demoscope1',
+            ])
+            ->setGrantType([
+                'authorization_code',
+                'password',
+                'implicit',
             ]);
         $manager->persist($model);
 
@@ -86,6 +91,9 @@ class AuthorizeFixture implements FixtureInterface
             ->setScope([
                 'demoscope1',
                 'demoscope2',
+            ])
+            ->setGrantType([
+                'authorization_code',
             ]);
         $manager->persist($model);
 
@@ -96,6 +104,11 @@ class AuthorizeFixture implements FixtureInterface
                 'demoscope1',
                 'demoscope2',
                 'demoscope3',
+            ])
+            ->setGrantType([
+                'authorization_code',
+                'password',
+                'implicit',
             ]);
         $manager->persist($model);
 
@@ -106,6 +119,9 @@ class AuthorizeFixture implements FixtureInterface
                 'demoscope1',
                 'demoscope2',
                 'demoscope3',
+            ])
+            ->setGrantType([
+                'client_credentials',
             ]);
         $manager->persist($model);
 

--- a/tests/TestBundle/Entity/Authorize.php
+++ b/tests/TestBundle/Entity/Authorize.php
@@ -53,6 +53,13 @@ class Authorize implements AuthorizeInterface
     protected $scope;
 
     /**
+     * @var array
+     *
+     * @ORM\Column(name="grant_type", type="array")
+     */
+    protected $grantType;
+
+    /**
      * Get id.
      *
      * @return int
@@ -132,5 +139,27 @@ class Authorize implements AuthorizeInterface
     public function getScope()
     {
         return $this->scope;
+    }
+
+    /**
+     * Set grant type.
+     *
+     * @param array $grantType
+     *
+     * @return Authorize
+     */
+    public function setGrantType($grantType)
+    {
+        $this->grantType = $grantType;
+    }
+
+    /**
+     * Get grant type.
+     *
+     * @return array
+     */
+    public function getGrantType()
+    {
+        return $this->grantType;
     }
 }


### PR DESCRIPTION
- Allows specific user/client combo to only use certain grant types
- E.g. This mean server can allow certain clients access to password
grant, but others only authorization code grants

This my first change that is actually a feature, and a breaking change.